### PR TITLE
Make test host configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ make clean/docker     # Clean docker resources
 make clean/deep       # Deep clean (artifacts + docker)
 ```
 
+### Environment variables
+
+The JMeter DSL tests read the target host and InfluxDB endpoint from the
+environment or equivalent JVM system properties. By default everything runs
+locally so these variables are optional.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TEST_HOST` (`-Dtest.host`)| `localhost` | Hostname of the gRPC service |
+| `INFLUX_URL` (`-Dinflux.url`)| `http://localhost:8086/write?db=perf-tests` | URL for InfluxDB listener |
+
+
 ## Service endpoints
 
 | Service | Port | URL |

--- a/tests/jmeter-dsl/app/src/test/java/org/example/perf/grpc/MaximumLoadTest.java
+++ b/tests/jmeter-dsl/app/src/test/java/org/example/perf/grpc/MaximumLoadTest.java
@@ -17,8 +17,13 @@ import us.abstracta.jmeter.javadsl.core.TestPlanStats;
 
 class MaximumLoadTest {
     private static final Logger log = LoggerFactory.getLogger(MaximumLoadTest.class);
-    private static final String TEST_HOST = "162.55.34.236";
-    private static final String INFLUX_URL = "http://162.55.34.236:8086/write?db=perf-tests";
+    private static final String TEST_HOST = System.getProperty(
+            "test.host",
+            System.getenv().getOrDefault("TEST_HOST", "localhost"));
+    private static final String INFLUX_URL = System.getProperty(
+            "influx.url",
+            System.getenv().getOrDefault("INFLUX_URL",
+                    "http://localhost:8086/write?db=perf-tests"));
     private static final int TEST_PORT = 50052;
 
     private static final class TestConfig {

--- a/tests/jmeter-dsl/app/src/test/java/org/example/perf/grpc/ReliabilityTest.java
+++ b/tests/jmeter-dsl/app/src/test/java/org/example/perf/grpc/ReliabilityTest.java
@@ -46,8 +46,13 @@ class ReliabilityTest {
         static final int REQUIRED_STABLE_WINDOWS = 6;
     }
 
-    private static final String TEST_HOST = "162.55.34.236";
-    private static final String INFLUX_URL = "http://162.55.34.236:8086/write?db=perf-tests";
+    private static final String TEST_HOST = System.getProperty(
+            "test.host",
+            System.getenv().getOrDefault("TEST_HOST", "localhost"));
+    private static final String INFLUX_URL = System.getProperty(
+            "influx.url",
+            System.getenv().getOrDefault("INFLUX_URL",
+                    "http://localhost:8086/write?db=perf-tests"));
     private static final int TEST_PORT = 50052;
 
     // reusing records from MaximumLoadTest


### PR DESCRIPTION
## Summary
- allow Max/Rel tests to read host and InfluxDB URL from env vars or system properties
- document new variables in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6845cb9d451083339500b826e96f5fd9