### PR TITLE
Add k6 service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,13 @@ services:
         max-size: "50m"
         max-file: "3"
 
+  k6:
+    image: grafana/k6
+    volumes:
+      - ./tests/k6:/scripts
+    networks:
+      - monitoring
+
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:v0.47.2
     container_name: cadvisor


### PR DESCRIPTION
## Summary
- add new `k6` service with `grafana/k6` image
- mount `tests/k6` directory inside the container
- attach the service to the monitoring network

## Testing
- `make test` *(fails: Nothing to be done)*
- `make test/max-load/k6` *(fails: Network is unreachable)*
- `make test/reliability/k6` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6845cba1f34883338204ed00f27d21f8