### PR TITLE
Add embedding cache utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,23 @@ Default JVM options for test execution:
 -XX:MaxGCPauseMillis=100
 -XX:+ParallelRefProcEnabled
 ```
+
+## Embedding cache
+
+The project now includes a small helper to cache numpy embeddings on disk. By default data is stored in `~/.cache/grpc-service-benchmark/embeddings`, but you can override the location by setting `EMBED_CACHE_DIR`.
+
+Example usage:
+
+```python
+from sentence_transformers import SentenceTransformer
+from tools.embed_cache import load_embeddings, save_embeddings
+
+text = "hello world"
+key = text
+
+emb = load_embeddings(key)
+if emb is None:
+    model = SentenceTransformer("all-MiniLM-L6-v2")
+    emb = model.encode([text])
+    save_embeddings(key, emb)
+```

--- a/scripts/embed_text.py
+++ b/scripts/embed_text.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Simple CLI to generate sentence embeddings with caching."""
+import argparse
+from sentence_transformers import SentenceTransformer
+
+from tools.embed_cache import load_embeddings, save_embeddings
+
+
+MODEL_NAME = "all-MiniLM-L6-v2"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate embeddings for text")
+    parser.add_argument("text", help="text to embed")
+    args = parser.parse_args()
+
+    key = args.text
+    emb = load_embeddings(key)
+    if emb is None:
+        model = SentenceTransformer(MODEL_NAME)
+        emb = model.encode([args.text])
+        save_embeddings(key, emb)
+
+    print(emb)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/embed_cache.py
+++ b/tools/embed_cache.py
@@ -1,0 +1,33 @@
+import os
+import hashlib
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+
+def _cache_dir() -> Path:
+    base = os.environ.get(
+        "EMBED_CACHE_DIR",
+        os.path.expanduser("~/.cache/grpc-service-benchmark/embeddings"),
+    )
+    path = Path(base)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _file_path(key: str) -> Path:
+    hashed = hashlib.sha256(key.encode("utf-8")).hexdigest()
+    return _cache_dir() / f"{hashed}.npy"
+
+
+def load_embeddings(key: str) -> Optional[np.ndarray]:
+    path = _file_path(key)
+    if path.exists():
+        return np.load(path)
+    return None
+
+
+def save_embeddings(key: str, data: np.ndarray) -> None:
+    path = _file_path(key)
+    np.save(path, data)


### PR DESCRIPTION
## Summary
- add helper module to load/save cached embeddings
- add simple CLI for embedding text with cache support
- document caching behavior in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684afc73c6f483338a8e9907f7a31511